### PR TITLE
feat: RSS-PZ-03 Save user entry data to Local Storage

### DIFF
--- a/src/pages/login/FormCreator.ts
+++ b/src/pages/login/FormCreator.ts
@@ -5,6 +5,7 @@ import {
   firstNameRules,
   surnameRules,
 } from '../../utils/createValidationRules';
+import FormSubmitHandler from '../../utils/FormSubmitHandler';
 
 export default class FormCreator {
   private formElement: HTMLElement;
@@ -24,6 +25,11 @@ export default class FormCreator {
     );
     this.loginButton = createLoginButton();
     this.formElement = this.createForm();
+    new FormSubmitHandler(
+      this.formElement,
+      this.firstNameField.getField(),
+      this.surnameField.getField()
+    );
   }
 
   private createForm(): HTMLElement {

--- a/src/utils/FormSubmitHandler.ts
+++ b/src/utils/FormSubmitHandler.ts
@@ -1,0 +1,20 @@
+export default class FormSubmitHandler {
+  constructor(
+    private formElement: HTMLElement,
+    private firstNameField: HTMLInputElement,
+    private surnameField: HTMLInputElement
+  ) {
+    this.setupSubmitListener();
+  }
+
+  private setupSubmitListener(): void {
+    this.formElement.addEventListener('submit', (event) => {
+      event.preventDefault();
+      const userData = {
+        firstName: this.firstNameField.value,
+        surname: this.surnameField.value,
+      };
+      localStorage.setItem('userEntry', JSON.stringify(userData));
+    });
+  }
+}


### PR DESCRIPTION
# Pull Request - Save user entry data to Local Storage (feat: RSS-PZ-03)
## Overview
This pull request introduces storing the user's first name and surname in the browser's local storage immediately after the submission of the login form. It meets the requirements specified in the feature ticket [RSS-PZ-03](https://github.com/rolling-scopes-school/tasks/blob/master/stage2/tasks/puzzle/stories/RSS-PZ-03.md).
## Features Implemented
* The user's first name and surname are captured and stored as a single JSON object in Local Storage upon form submission.
* The data persists in Local Storage across page reloads and browser sessions.
## Screenshot
![RSS-PZ-03](https://github.com/hannakulikowska/rss-puzzle/assets/80547490/072004c7-4be8-41e1-a659-f484834bf85a)
