### PR TITLE
fix: RSS-PZ-05 Move application name to header

### DIFF
--- a/src/components/AppName.ts
+++ b/src/components/AppName.ts
@@ -1,0 +1,19 @@
+import ElementCreator from '../utils/elementСreator';
+
+export default class Greeting {
+  private appNameElement: HTMLElement;
+
+  constructor() {
+    const element = new ElementCreator({
+      tag: 'h1',
+      classNames: ['header__title'],
+      textContent: 'RSS-Puzzle',
+    }).getElement();
+
+    this.appNameElement = element!;
+  }
+
+  public getElement(): HTMLElement {
+    return this.appNameElement;
+  }
+}

--- a/src/components/Header.ts
+++ b/src/components/Header.ts
@@ -1,12 +1,15 @@
 import ElementCreator from '../utils/elementСreator';
 import LogoutButton from './LogoutButton';
+import Greeting from './AppName';
 
 export default class Header {
   private headerElement: HTMLElement;
 
   constructor() {
     this.headerElement = this.createHeader();
+    const greeting = new Greeting();
     const logoutButton = new LogoutButton();
+    this.headerElement.appendChild(greeting.getElement());
     this.headerElement.appendChild(logoutButton.getButton());
   }
 

--- a/src/pages/start/StartContent.ts
+++ b/src/pages/start/StartContent.ts
@@ -5,12 +5,6 @@ export const contentWrapper = generateElement({
   classNames: ['start__content'],
 });
 
-export const titleElement = generateElement({
-  tag: 'h1',
-  textContent: 'RSS-Puzzle',
-  classNames: ['start__title'],
-});
-
 export const greetingElement = generateElement({
   tag: 'h2',
   textContent:

--- a/src/pages/start/StartPage.ts
+++ b/src/pages/start/StartPage.ts
@@ -1,4 +1,4 @@
-import { contentWrapper, titleElement, paragraphElement } from './StartContent';
+import { contentWrapper, paragraphElement } from './StartContent';
 import ElementCreator from '../../utils/elementСreator';
 import Greeting from './StartGreeting';
 
@@ -13,7 +13,6 @@ export default class StartPage {
 
     if (contentWrapper) {
       wrapper.addInnerElement(contentWrapper);
-      if (titleElement) contentWrapper.appendChild(titleElement);
       contentWrapper.appendChild(greeting);
       if (paragraphElement) contentWrapper.appendChild(paragraphElement);
     }

--- a/src/styles/components/header.scss
+++ b/src/styles/components/header.scss
@@ -1,4 +1,11 @@
 .header {
-  @include flex(flex-end, center);
+  @include flex(space-between, center);
   margin-bottom: 4em;
+}
+
+.header__title {
+  color: $color-active;
+  font-weight: bold;
+  font-size: 2em;
+  text-transform: uppercase;
 }

--- a/src/styles/components/page-wrapper.scss
+++ b/src/styles/components/page-wrapper.scss
@@ -1,9 +1,8 @@
 .page-wrapper {
-  max-width: 1920px;
-  height: 100%;
+  max-width: 1024px;
+  height: 100dvh;
   padding: 1em;
   margin: 0 auto;
-  @include backgroundImage('src/assets/images/bg-image.webp');
 
   &#login {
     @include flex(center, center);

--- a/src/styles/mixins.scss
+++ b/src/styles/mixins.scss
@@ -10,4 +10,5 @@
   background-position: center;
   background-repeat: no-repeat;
   background-size: cover;
+  background-attachment: fixed;
 }

--- a/src/styles/pages/start/start-page.scss
+++ b/src/styles/pages/start/start-page.scss
@@ -5,18 +5,12 @@
 }
 
 .start__content {
-  max-width: 50em;
   padding: 2em;
   background: $color-white-bg;
   border-radius: 1em;
   @include flex(flex-start, center);
   flex-direction: column;
   animation: bounceInTop 2s ease 0s 1 normal forwards;
-}
-.start__title {
-  font-size: 2.5em;
-  text-transform: uppercase;
-  letter-spacing: 1px;
 }
 
 .start__description {

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -8,13 +8,18 @@
 @import './animations/scaleUpCenter.scss';
 @import './animations/attention.scss';
 
+html,
+body {
+  width: 100%;
+  height: 100dvh;
+  margin: 0;
+  padding: 0;
+}
+
 html {
   font-family: 'Open Sans';
   font-weight: normal;
   font-style: normal;
-  margin: 0;
-  padding: 0;
-  height: 100vh;
 
   @media screen and (max-width: 768px) {
     font-size: 12px;
@@ -26,7 +31,7 @@ html {
 }
 
 body {
-  height: 100%;
+  @include backgroundImage('src/assets/images/bg-image.webp');
 }
 
 @import './components/page-wrapper.scss';


### PR DESCRIPTION
# Pull Request - Move application name to header (feat: RSS-PZ-05)
## Overview
This pull request introduces key updates to the UI, including adjustments to the background image property, repositioning the application name into the header, and CSS property updates for enhanced content display. It meets the requirements specified in the feature ticket [RSS-PZ-05](https://github.com/rolling-scopes-school/tasks/blob/master/stage2/tasks/puzzle/stories/RSS-PZ-05.md).
## Updates and Adjustments:
* Modified the background image property to ensure it covers the entire screen without leaving any blank spaces during scrolling or resizing.
* Moved the application name to the header for a more centralized and prominent display.
* Updated various CSS properties to improve the visual presentation and readability of the content on the page.
## Screenshot
![RSS-PZ-05-fix](https://github.com/hannakulikowska/rss-puzzle/assets/80547490/a4e9304b-1592-4e06-bfc3-d589bad19f6b)