### PR TITLE
feat: RSS-PZ-07 Include a Start button on the Start screen for navigation to the Main page

### DIFF
--- a/src/app/initApp.ts
+++ b/src/app/initApp.ts
@@ -3,7 +3,7 @@ import LoginPage from '../pages/login/LoginPage';
 import StartPage from '../pages/start/StartPage';
 import Header from '../components/Header';
 
-const pageWrapper = new PageWrapper();
+export const pageWrapper = new PageWrapper();
 
 export default function initApp() {
   pageWrapper.cleanWrapper();

--- a/src/components/AppName.ts
+++ b/src/components/AppName.ts
@@ -1,6 +1,6 @@
 import ElementCreator from '../utils/elementСreator';
 
-export default class Greeting {
+export default class AppName {
   private appNameElement: HTMLElement;
 
   constructor() {

--- a/src/components/Button.ts
+++ b/src/components/Button.ts
@@ -1,0 +1,35 @@
+import ElementCreator from '../utils/elementСreator';
+import ButtonParams from '../models/interfaces/ButtonParams';
+
+export default class Button {
+  private button: HTMLElement;
+
+  constructor(params: ButtonParams) {
+    const {
+      textContent,
+      classNames = [],
+      id,
+      type = 'button',
+      disabled = false,
+      onClick,
+    } = params;
+
+    const attributes: { [key: string]: string } = { type };
+    if (disabled) attributes.disabled = 'true';
+
+    const elementCreator = new ElementCreator({
+      tag: 'button',
+      classNames: ['button', ...classNames],
+      id,
+      textContent,
+      callback: onClick,
+      attributes,
+    });
+
+    this.button = elementCreator.getElement()!;
+  }
+
+  public getElement(): HTMLElement {
+    return this.button;
+  }
+}

--- a/src/components/Header.ts
+++ b/src/components/Header.ts
@@ -1,15 +1,15 @@
 import ElementCreator from '../utils/elementСreator';
 import LogoutButton from './LogoutButton';
-import Greeting from './AppName';
+import AppName from './AppName';
 
 export default class Header {
   private headerElement: HTMLElement;
 
   constructor() {
     this.headerElement = this.createHeader();
-    const greeting = new Greeting();
+    const appNameElement = new AppName();
     const logoutButton = new LogoutButton();
-    this.headerElement.appendChild(greeting.getElement());
+    this.headerElement.appendChild(appNameElement.getElement());
     this.headerElement.appendChild(logoutButton.getButton());
   }
 

--- a/src/models/interfaces/ButtonParams.ts
+++ b/src/models/interfaces/ButtonParams.ts
@@ -1,6 +1,8 @@
 export default interface ButtonParams {
-  type: 'button' | 'submit' | 'reset';
   textContent: string;
   classNames?: string[];
+  id?: string;
+  type?: 'button' | 'submit' | 'reset';
   disabled?: boolean;
+  onClick?: (event: Event) => void;
 }

--- a/src/pages/main/MainPage.ts
+++ b/src/pages/main/MainPage.ts
@@ -1,0 +1,12 @@
+import ElementCreator from '../../utils/elementСreator';
+
+export default class MainPage {
+  public getMainPage(): HTMLElement {
+    const wrapper = new ElementCreator({
+      tag: 'main',
+      classNames: ['main'],
+    });
+
+    return wrapper.getElement() as HTMLElement;
+  }
+}

--- a/src/pages/start/StartButton.ts
+++ b/src/pages/start/StartButton.ts
@@ -1,0 +1,13 @@
+import MainPage from '../main/MainPage';
+import Button from '../../components/Button';
+import { pageWrapper } from '../../app/initApp';
+
+export const startButton = new Button({
+  textContent: 'Start',
+  classNames: ['start-button'],
+  onClick: () => {
+    const mainPageContent = new MainPage().getMainPage();
+    pageWrapper.cleanWrapper();
+    pageWrapper.getWrapper().appendChild(mainPageContent);
+  },
+});

--- a/src/pages/start/StartContent.ts
+++ b/src/pages/start/StartContent.ts
@@ -5,13 +5,6 @@ export const contentWrapper = generateElement({
   classNames: ['start__content'],
 });
 
-export const greetingElement = generateElement({
-  tag: 'h2',
-  textContent:
-    'Hello, [Имя] [Фамилия]! Ready to puzzle out some phrases? Your adventure in English awaits!',
-  classNames: ['start__greeting'],
-});
-
 export const paragraphElement = generateElement({
   tag: 'p',
   textContent:

--- a/src/pages/start/StartPage.ts
+++ b/src/pages/start/StartPage.ts
@@ -1,6 +1,7 @@
 import { contentWrapper, paragraphElement } from './StartContent';
 import ElementCreator from '../../utils/elementСreator';
 import Greeting from './StartGreeting';
+import { startButton } from './StartButton';
 
 export default class StartPage {
   public getContent(): HTMLElement {
@@ -12,9 +13,13 @@ export default class StartPage {
     const greeting = new Greeting().getElement();
 
     if (contentWrapper) {
+      while (contentWrapper.firstChild) {
+        contentWrapper.removeChild(contentWrapper.firstChild);
+      }
       wrapper.addInnerElement(contentWrapper);
       contentWrapper.appendChild(greeting);
       if (paragraphElement) contentWrapper.appendChild(paragraphElement);
+      contentWrapper.appendChild(startButton.getElement());
     }
 
     return wrapper.getElement() as HTMLElement;

--- a/src/styles/components/button.scss
+++ b/src/styles/components/button.scss
@@ -1,5 +1,4 @@
 .button {
-  border: 2px solid $color-white;
   border-radius: $border-radius;
   transition: $transition;
 
@@ -9,5 +8,30 @@
 
   &:disabled {
     cursor: default;
+  }
+}
+
+.button[type='submit'] {
+  border: 2px solid $color-white;
+}
+
+.button[type='button'] {
+  padding: 0.5em;
+  font-size: 2em;
+  line-height: 0.8;
+  animation: ScaleUpCenter 2s ease 0s 1 normal forwards;
+  background: transparent;
+  border: 2px solid $color-active;
+  color: $color-active;
+
+  &:active {
+    scale: 0.8;
+  }
+
+  @media screen and (hover: hover) {
+    &:hover {
+      background: $color-active;
+      color: $color-white;
+    }
   }
 }

--- a/src/styles/pages/start/logout-button.scss
+++ b/src/styles/pages/start/logout-button.scss
@@ -1,29 +1,4 @@
-.start__logout-button {
-  max-width: 4.5em;
-  max-height: 4.5em;
-  padding: 0.7em 1em;
-  z-index: 1;
-  transition: $transition;
-  animation: ScaleUpCenter 2s ease 0s 1 normal forwards;
-  background: transparent;
-  border: 2px solid $color-active;
-  border-radius: 100%;
-  color: $color-active;
-
-  &:active {
-    scale: 0.8;
-  }
-
-  @media screen and (hover: hover) {
-    &:hover {
-      background: $color-active;
-      color: $color-white;
-    }
-  }
-}
-
 .icon-logout-1:before {
   content: '\e805';
   margin: 0;
-  font-size: 2.5em;
 }


### PR DESCRIPTION
# Pull Request - Include a Start button on the Start screen for navigation to the Main page (feat: RSS-PZ-07)
## Overview
This pull request introduces a Start button on the application's Start screen for seamless navigation to the Main game page. It meets the requirements specified in the feature ticket [RSS-PZ-07](https://github.com/rolling-scopes-school/tasks/blob/master/stage2/tasks/puzzle/stories/RSS-PZ-07.md).
## Features Implemented
* Added a prominently displayed Start button to the Start screen, serving as the primary user interaction element for transitioning to the game.
* Implemented functionality where clicking the Start button navigates the user directly to the Main game page, enhancing the user experience.
* Created and applied common CSS styles for buttons to ensure consistency in design and user interface throughout the application.
## Screenshot
![RSS-PZ-07](https://github.com/hannakulikowska/rss-puzzle/assets/80547490/fbb769ea-9bdf-44d8-ac0f-dfc108da629d)